### PR TITLE
add ability to register behaviors on item emission and error on an Ev…

### DIFF
--- a/components/api/src/main/java/com/hotels/styx/api/Eventual.java
+++ b/components/api/src/main/java/com/hotels/styx/api/Eventual.java
@@ -20,6 +20,7 @@ import org.reactivestreams.Subscriber;
 import reactor.core.publisher.Mono;
 
 import java.util.concurrent.CompletionStage;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 /**
@@ -111,6 +112,26 @@ public final class Eventual<T> implements Publisher<T> {
     public Eventual<T> onError(Function<Throwable, ? extends Eventual<? extends T>> errorHandler) {
         return fromMono(Mono.from(publisher)
                 .onErrorResume(value -> Mono.from(errorHandler.apply(value))));
+    }
+
+    /**
+     * Add a behavior that is triggered when this eventual emits an item successfully.
+     *
+     * @param emitted - the callback to be executed when an item is emitted
+     * @return a new {@link Eventual} with the callback registered
+     */
+    public Eventual<T> doOnEmit(Consumer<T> emitted) {
+        return fromMono(Mono.from(publisher).doOnNext(emitted));
+    }
+
+    /**
+     * Add a behavior that is triggered when this eventual terminates with an error.
+     *
+     * @param emitted - a callback to be executed when the  {@link Throwable} that caused the termination
+     * @return a new {@link Eventual} with the callback registered
+     */
+    public Eventual<T> doOnError(Consumer<? super Throwable> emitted) {
+        return fromMono(Mono.from(publisher).doOnError(emitted));
     }
 
     /**

--- a/components/api/src/test/java/com/hotels/styx/api/EventualTest.java
+++ b/components/api/src/test/java/com/hotels/styx/api/EventualTest.java
@@ -88,4 +88,32 @@ public class EventualTest {
                 .expectNext("mapped error: ouch")
                 .verifyComplete();
     }
+
+    @Test
+    public void triggersOnEmit() {
+        StringBuffer init = new StringBuffer("hello");
+        Eventual<String> eventual =
+                Eventual.of("hello")
+                        .doOnEmit(item -> init.append(" world") );
+
+        StepVerifier.create(eventual)
+                .expectNext("hello")
+                .verifyComplete();
+
+        assertEquals("hello world", init.toString());
+    }
+
+    @Test
+    public void triggersOnError() {
+        StringBuffer init = new StringBuffer("hello");
+        Eventual<Object> eventual =
+                Eventual.error(new RuntimeException("ouch"))
+                        .doOnError(item -> init.append(" world"));
+
+        StepVerifier.create(eventual)
+                .expectError()
+                .verify();
+
+        assertEquals("hello world", init.toString());
+    }
 }


### PR DESCRIPTION
…entual

Eventual is a publisher that emits 1 item or terminates with an error. It exposes operators that can be used to transform emitted items or errors that were thrown, however it does not provide a way to add behaviors that will be triggered when an error was the cause of termination or when an item was emitted. 

Mono is a publisher that emits 0 or 1 items and completes successfully or terminates with an error. Mono does provide doOnXXX operators and these are different from map/flatmap and similar operators that are meant for transformations on the emitted items before they proceed through the reactive chain. The doOnXXX operators are meant for adding behaviors that are side effects (for example logging) and do not have any effect on items that are published. 

Since an Eventual has 2 terminal conditions as opposed to 3 like the mono, I agree that adding a method like onNext can be confusing. For a Mono, the onNext behaviors are NOT triggered when there were 0 items emitted. So, for an Eventual, we could do something like doOnEmitt and doOnError. 

These would be useful for peeking into a sequence without modifying it in any way, the recommended operators from reactor reference for such use cases are discussed here: https://projectreactor.io/docs/core/release/reference/#which.peeking

Currently, our use case is, we do some auditing and access logging on responses. Since we don't want to transform the response in any way, and only trigger behaviors that consume a response (or error) we have to do things similar to the following, given the Eventual api: 

```
return new Eventual(Mono.from(chain.proceed(request)).doOnNext(resp -> auditResp(resp)).doOnError(error -> auditError(error))
```
The above works and is what we are resigned to use at the moment. I believe changes to the API to allow for such triggers to be registered would be useful. I've created this PR to share what this could look like, however, I might be missing context around why these may be problematic. 

Regarding subscriptions, I believe updating documentation to explicitly state that double subscriptions are not allowed would be good. The doc literally says the following
```
 * Eventual is meant to expose HTTP responses to {@link HttpInterceptor}s in
 * a Styx proxy. As such {@code Eventual} only exposes operations that are
 * meaningful and safe for processing live network traffic.
```
which is false, and using subscribe will cause runtime exceptions. I do understand why multiple subscriptions should be avoided for network traffic and in this case (thanks for that clarification). 
